### PR TITLE
extended model ckpt epoch to 5 digits

### DIFF
--- a/args/base_arg_parser.py
+++ b/args/base_arg_parser.py
@@ -138,11 +138,8 @@ class BaseArgParser(object):
         ckpt_files = sorted([name for name in os.listdir(
             args.ckpt_dir) if name.split(".", 1)[1] == "pth.tar"])
 
-        if 'best.pth.tar' in ckpt_files:
-            ckpt_files.remove('best.pth.tar')
-
         if len(ckpt_files) > 0:
-            epoch = int(ckpt_files[-1][:3])
+            epoch = int(ckpt_files[-1][:5])
         else:
             epoch = 0
         return epoch

--- a/saver/model_saver.py
+++ b/saver/model_saver.py
@@ -107,7 +107,7 @@ class ModelSaver(object):
 
         if ckpt_path is None:
             if model_name and hasattr(self.args, 'load_epoch'):
-                file_name = f'{str(self.args.load_epoch).zfill(3)}_{model_name}.pth.tar'
+                file_name = f'{str(self.args.load_epoch).zfill(5)}_{model_name}.pth.tar'
                 ckpt_path = os.path.join(self.ckpt_dir, file_name)
             else:
                 print("No checkpoint found. Failed to load load model checkpoint.")

--- a/saver/model_saver.py
+++ b/saver/model_saver.py
@@ -73,7 +73,7 @@ class ModelSaver(object):
 
         model.to(device)
 
-        file_name = f'{str(epoch).zfill(3)}_{model_name}.pth.tar'
+        file_name = f'{str(epoch).zfill(5)}_{model_name}.pth.tar'
 
         ckpt_path = os.path.join(self.ckpt_dir, file_name)
         torch.save(ckpt_dict, ckpt_path)


### PR DESCRIPTION
User reported bug in which continuing training beyond epoch 999 was not working as we hard coded the epoch to be displayed in 3 digits. Extended this to 5 digits to allow longer training.