### PR TITLE
Fixed training loop's number of iterations

### DIFF
--- a/mask_cyclegan_vc/train.py
+++ b/mask_cyclegan_vc/train.py
@@ -174,7 +174,7 @@ class MaskCycleGANVCTraining(object):
     def train(self):
         """Implements the training loop for MaskCycleGAN-VC
         """
-        for epoch in range(self.start_epoch, self.num_epochs):
+        for epoch in range(self.start_epoch, self.num_epochs + 1):
             self.logger.start_epoch()
 
             for i, (real_A, mask_A, real_B, mask_B) in enumerate(tqdm(self.train_dataloader)):


### PR DESCRIPTION
Hey, 
I noticed this minor detail in the code. Since start_epoch is equal to 1 by default, if, for example, num_epochs is specified to be 50, the loop will exit after completing the 49th epoch.